### PR TITLE
Add types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,16 +8,20 @@
   },
   "main": "./index.js",
   "module": "./index.mjs",
+  "types": "./index.d.ts",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./index.mjs",
       "require": "./index.js"
     },
     "./date": {
+      "types": "./date/index.d.ts",
       "import": "./date/index.mjs",
       "require": "./date/index.js"
     },
     "./date/mini": {
+      "types": "./date/mini.d.ts",
       "import": "./date/mini.mjs",
       "require": "./date/mini.js"
     }


### PR DESCRIPTION
**Changes**
* Add `types` entries in `package.json`

**References**
* [publint](https://github.com/bluwy/publint) was used to detect errors/warnings
* [Read more](https://nodejs.org/api/packages.html) about the "best practices" for a `package.json` file

There is still room for improvement (having separate declaration files for both CJS and ESM) but this requires changes in the build pipeline which I consider out-of-scope for this fix.

Closes #3

