### PR TITLE
fix: interprets strings as UTC

### DIFF
--- a/src/date/mini.mjs
+++ b/src/date/mini.mjs
@@ -6,7 +6,7 @@ export class UTCDateMini extends Date {
       this.setTime(
         arguments.length === 1
           ? typeof arguments[0] === "string"
-            ? +new Date(arguments[0])
+            ? Date.parse(arguments[0])
             : arguments[0]
           : Date.UTC(...arguments)
       );

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { UTCDate } from "./date";
 
 describe("UTCDate", () => {
@@ -17,8 +17,8 @@ describe("UTCDate", () => {
       expect(+new UTCDate(540000000000)).toBe(540000000000);
     });
 
-    it("allows to parse the string", () => {
-      expect(+new UTCDate("2023-05-03")).toBe(+new Date("2023-05-03"));
+    it("allows to parse the string in UTC", () => {
+      expect(new UTCDate("2023-05-01").getTime()).toBe(Date.UTC(2023, 4, 1));
     });
 
     it("allows to create date from another date", () => {


### PR DESCRIPTION
Calling `new UTCDate()` with a string yields wrong results. For example, if I am right of UTC (e.g. Berlin), then I would expect 

```js
console.log(new UTCDate("2025-07-01"))
//=> 'Tue Jul 1 2025 00:00:00 GMT+0000 (Coordinated Universal Time)'
```

However, it insteads outputs it in local time:
```
//=> 'Mon Jun 30 2025 22:00:00 GMT+0000 (Coordinated Universal Time)'
```

This PR fixes it by treating the string as UTC 