### PR TITLE
Fix type definition of `UTCDateMini`

### DIFF
--- a/src/date/mini.d.ts
+++ b/src/date/mini.d.ts
@@ -12,4 +12,4 @@ import { type UTCDate } from "./index.ts";
  *
  * For the complete version, see `UTCDate`.
  */
-export const UTCDateMini: UTCDate;
+export const UTCDateMini: typeof UTCDate;


### PR DESCRIPTION
Now `new UTCDateMini(2020, 0, 1)` in TypeScript raises type error `'Type 'UTCDate' has no construct signatures.'`, and this PR will fix it.